### PR TITLE
docs: Require 95% coverage thresholds for new packages

### DIFF
--- a/docs/NEW-PACKAGE.md
+++ b/docs/NEW-PACKAGE.md
@@ -48,8 +48,18 @@ module.exports = {
     '!<rootDir>/src/**/*.test.ts',
     '!<rootDir>/src/**/*.d.ts',
   ],
+  coverageThreshold: {
+    global: {
+      branches: 95,
+      functions: 95,
+      lines: 95,
+      statements: 95,
+    },
+  },
 }
 ```
+
+**REQUIRED**: All new packages must set minimum coverage thresholds of **95%** for branches, functions, lines, and statements. This ensures high test quality and prevents regressions.
 
 See `packages/cli/jest.config.cjs` or `packages/ya-modbus-driver-xymd1/jest.config.cjs` for reference.
 
@@ -118,6 +128,8 @@ After creating the package:
 - [ ] `npm run build` builds the package
 - [ ] `npm run test` from package directory runs tests
 - [ ] `npm test` from root discovers and runs package tests
+- [ ] Coverage thresholds are set to 95% in jest.config.cjs
+- [ ] Tests achieve at least 95% coverage across all metrics
 - [ ] `npm run lint` from package directory lints successfully
 - [ ] `npm run lint` from root includes the package
 - [ ] AGENTS.md follows guidelines in `docs/AGENTS-MAINTENANCE.md`


### PR DESCRIPTION
## Summary

Updates the NEW-PACKAGE.md documentation to require minimum coverage thresholds of 95% for all new packages.

## Changes

### Documentation Updates
- Added `coverageThreshold` configuration to the jest.config.cjs template
- Added two new items to the verification checklist:
  - Coverage thresholds are set to 95% in jest.config.cjs
  - Tests achieve at least 95% coverage across all metrics
- Emphasized the requirement with a **REQUIRED** marker

### Rationale

This standardizes test quality across the monorepo by:
1. **Preventing regressions** - CI will fail if coverage drops below 95%
2. **Ensuring quality** - High coverage threshold encourages comprehensive testing
3. **Consistency** - All packages follow the same quality bar
4. **Aligning with practice** - ya-modbus-driver-xymd1 already implements this standard

## Example Configuration

```javascript
coverageThreshold: {
  global: {
    branches: 95,
    functions: 95,
    lines: 95,
    statements: 95,
  },
}
```

## Context

This requirement was successfully implemented in PR #44 (ya-modbus-driver-xymd1 correction registers) where it caught missing test coverage for edge cases. The practice proved valuable and should be applied to all future packages.

## Related

- #44 - XYMD1 correction registers (implemented 95% threshold)
- Existing packages (cli, driver-xymd1) already meet or exceed this standard

## Checklist

- [x] Documentation is clear and actionable
- [x] Template code is correct and tested
- [x] Verification checklist is comprehensive
- [x] Rationale is explained
- [x] No breaking changes (applies only to new packages)