### PR TITLE
feat(cli): improve help organization with option and command groups

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -76,8 +76,6 @@ Examples:
   $ ya-modbus write --host 192.168.1.100 --slave-id 1 --data-point voltage --value 220
   $ ya-modbus discover --port /dev/ttyUSB0 --strategy quick
   $ ya-modbus show-defaults --driver ya-modbus-driver-xymd1
-
-Documentation: https://github.com/groupsky/ya-modbus-mqtt-bridge-2
     `
   )
 


### PR DESCRIPTION
## Summary

Improves CLI user experience by organizing help output using Commander.js 14's grouping features:

- **Option groups**: Groups related options together (Driver, Connection, RTU, TCP, Data, Output)
- **Command groups**: Organizes commands by category (Device Operations, Discovery, Utilities)
- **Examples section**: Adds common usage patterns to main help
- **Clearer RTU vs TCP choice**: Explicitly indicates mutually exclusive connection options

## Motivation

The previous help output listed all options and commands in a flat structure, making it difficult for users to:
- Understand which options are related
- Distinguish between RTU and TCP connection options
- Find relevant commands quickly

## Changes

### Option Grouping
Options are now organized into logical groups:
- **Driver Options**: Driver package selection
- **Connection Options**: Common connection settings (slave-id, timeout)
- **RTU Connection**: Serial-specific options (port, baud-rate, parity, etc.)
- **TCP Connection**: Network-specific options (host, tcp-port)
- **Data Selection/Options**: Command-specific data handling
- **Output Options**: Formatting and verbosity controls

### Command Grouping
Commands are categorized by purpose:
- **Device Operations**: read, write
- **Device Discovery**: discover
- **Driver Utilities**: show-defaults

### Examples
Added practical examples to the main help showing common usage patterns.

## Testing

- ✅ All existing tests pass (397 tests)
- ✅ Manually verified help output for all commands
- ✅ No breaking changes to command behavior

## Example Output

**Before:**
```
Options:
  -d, --driver <package>  ...
  -p, --port <path>       ...
  -h, --host <host>       ...
  ...
```

**After:**
```
Driver Options:
  -d, --driver <package>  ...

Connection Options:
  -s, --slave-id <id>     ...
  --timeout <ms>          ...

RTU Connection (choose this OR TCP):
  -p, --port <path>       ...
  -b, --baud-rate <rate>  ...
  ...

TCP Connection (choose this OR RTU):
  -h, --host <host>       ...
  --tcp-port <port>       ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)