### PR TITLE
feat(cli): add runtime signature check for createDriver

### DIFF
--- a/packages/cli/src/driver-loader/loader.test.ts
+++ b/packages/cli/src/driver-loader/loader.test.ts
@@ -125,6 +125,24 @@ describe('Driver Loader', () => {
     await expect(loadDriver({ localPackage: true })).rejects.toThrow()
   })
 
+  test('should accept createDriver with correct signature (1 parameter)', async () => {
+    // The xymd1 driver has the correct createDriver signature
+    const driverMetadata = await loadDriver({ driverPackage: 'ya-modbus-driver-xymd1' })
+
+    expect(driverMetadata.createDriver).toBeDefined()
+    // Verify it's a function with exactly 1 parameter
+    expect(typeof driverMetadata.createDriver).toBe('function')
+    expect(driverMetadata.createDriver.length).toBe(1)
+  })
+
+  // Note: Testing createDriver signature validation with wrong parameter counts
+  // requires complex ES module mocking (jest.unstable_mockModule or test fixtures).
+  // The validation logic (function.length !== 1) is straightforward and will catch:
+  // - () => ... (0 params) - error message: "expected 1 parameter, got 0"
+  // - (a, b) => ... (2+ params) - error message: "expected 1 parameter, got 2"
+  // - (config = {}) => ... (default param) - error message: "expected 1 parameter, got 0"
+  // Integration testing with actual driver packages will exercise this validation.
+
   // Note: Testing local package loading with dynamic imports is complex.
   // This is covered by integration tests with actual driver packages.
 })

--- a/packages/cli/src/driver-loader/loader.ts
+++ b/packages/cli/src/driver-loader/loader.ts
@@ -190,6 +190,14 @@ export async function loadDriver(options: LoadDriverOptions = {}): Promise<Loade
       throw new Error('createDriver must be a function')
     }
 
+    if (createDriver.length !== 1) {
+      throw new Error(
+        `Invalid createDriver signature: expected 1 parameter, got ${createDriver.length}.\n` +
+          'Fix: export const createDriver = (config: DriverConfig) => Promise<DeviceDriver>\n' +
+          'See: CreateDriverFunction type in @ya-modbus/driver-types'
+      )
+    }
+
     // Build result object conditionally to satisfy exactOptionalPropertyTypes
     const result: LoadedDriver = {
       createDriver: createDriver as CreateDriverFunction,


### PR DESCRIPTION
## Summary

- Adds runtime validation to ensure `createDriver` function has exactly 1 parameter
- Validates signature using `Function.length` to catch common errors (0 params, 2+ params, default parameters)
- Provides clear error messages with fix guidance and type reference when validation fails
- Includes test coverage for correct signature and documentation for error cases

## Test plan

- [x] Test passes with correctly-signed createDriver (1 parameter)
- [x] Validation logic documented for edge cases (0 params, 2+ params, default params)