### PR TITLE
test(cli): fix flaky timing test in device-identifier

### DIFF
--- a/packages/cli/src/discovery/device-identifier.test.ts
+++ b/packages/cli/src/discovery/device-identifier.test.ts
@@ -146,7 +146,8 @@ describe('identifyDevice', () => {
 
       const result = await identifyDevice(mockClient as ModbusRTU)
 
-      expect(result.responseTimeMs).toBeGreaterThanOrEqual(100)
+      // Allow for timing precision variations (±1ms)
+      expect(result.responseTimeMs).toBeGreaterThanOrEqual(99)
       expect(result.responseTimeMs).toBeLessThan(200)
     })
   })


### PR DESCRIPTION
## Summary
- Fix flaky test that fails due to JavaScript timer imprecision
- Add ±1ms tolerance to slow response timing assertion
- Matches existing pattern used in fast response test

## Root Cause
The test uses `setTimeout(resolve, 100)` and expects `responseTimeMs >= 100`, but JavaScript timers can fire slightly early (e.g., 99.378ms), causing intermittent failures in CI.

## Test Plan
- [x] Verified test passes locally
- [x] Fix matches existing timing tolerance pattern in same test file
- [x] Code review approved