### PR TITLE
docs: add codecov badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.0+-blue.svg)](https://www.typescriptlang.org/)
 [![Node](https://img.shields.io/badge/Node-24+-green.svg)](https://nodejs.org/)
+[![codecov](https://codecov.io/gh/groupsky/ya-modbus-mqtt-bridge/graph/badge.svg)](https://codecov.io/gh/groupsky/ya-modbus-mqtt-bridge)
 
 ## Features
 


### PR DESCRIPTION
## Summary

- Added codecov badge to README badge section

## Test plan

- [x] Verify badge displays correctly in README
- [x] Confirm badge links to codecov project page