### PR TITLE
refactor(mqtt-bridge): remove duplicate consecutiveFailures tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13500,6 +13500,7 @@
     "packages/device-profiler": {
       "name": "@ya-modbus/device-profiler",
       "version": "0.1.0",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
         "@ya-modbus/driver-types": "^0.0.0",
         "@ya-modbus/transport": "^0.0.0",

--- a/packages/mqtt-bridge/src/index.ts
+++ b/packages/mqtt-bridge/src/index.ts
@@ -96,18 +96,13 @@ export function createBridge(
   }
 
   // Handle polling errors
-  const handlePollingError = (deviceId: string, error: Error): number => {
+  const handlePollingError = (deviceId: string, error: Error, failureCount: number): void => {
     console.error(`Polling error for device ${deviceId}:`, error)
 
-    const device = deviceManager.getDevice(deviceId)
-    const consecutiveFailures = (device?.consecutiveFailures ?? 0) + 1
-
     deviceManager.updateDeviceState(deviceId, {
-      consecutiveFailures,
+      consecutiveFailures: failureCount,
       errors: [error.message],
     })
-
-    return consecutiveFailures
   }
 
   const pollingScheduler =


### PR DESCRIPTION
## Summary

Removes duplicate tracking of `consecutiveFailures` between `PollingScheduler` and `DeviceManager`, and fixes two critical bugs in polling state management.

## Problem

1. **Duplicate State Tracking**: Both `PollingScheduler` and `DeviceStatus` tracked consecutive failures, causing synchronization complexity
2. **Data Callback Bug**: Polling success followed by MQTT publish failure kept devices in backoff mode indefinitely
3. **Error Callback Bug**: Error callback exceptions froze the failure count, preventing backoff activation

## Solution

**Architecture**:
- `DeviceManager` is the single source of truth for `consecutiveFailures`
- `PollingScheduler` maintains minimal `lastFailureCount` cache for backoff calculation only
- Error callback decoupled from state management - receives failure count as informational parameter

**Bug Fix #1 - Data Callback State Management**:
- Root cause: `lastFailureCount = 0` was inside try-catch, only executed if callback succeeded
- Impact: Successful poll + failed MQTT publish = device stuck in backoff
- Fix: Reset failure count BEFORE callback invocation - polling success is independent of callback result
- Location: `polling-scheduler.ts:134`

**Bug Fix #2 - Error Callback State Decoupling**:
- Root cause: State management coupled with error callback execution
- Impact: Error callback throwing exceptions prevented failure count increment, breaking backoff
- Fix: Scheduler owns and increments `lastFailureCount`, passes it to callback as parameter
- Breaking change: `ErrorCallback` signature changed from `(deviceId, error) => number` to `(deviceId, error, failureCount) => void`
- Location: `polling-scheduler.ts:148-155`, `index.ts:99-106`

**Additional Improvements**:
- Add defensive error handling for both data and error callbacks
- Callbacks throwing exceptions now logged but don't break polling state machine

## Changes

**Files Modified**:
- `src/polling-scheduler.ts`:
  - Change `ErrorCallback` type from `(deviceId, error) => number` to `(deviceId, error, failureCount) => void`
  - Move `lastFailureCount = 0` before data callback invocation
  - Increment `lastFailureCount` before error callback invocation
  - Add try-catch around both callbacks with error logging
- `src/index.ts`:
  - Update `handlePollingError` signature to accept `failureCount` parameter (void return)
  - Remove local failure count calculation - use scheduler's count
- Test files:
  - Add TDD regression test for data callback state management
  - Add TDD regression test for error callback state decoupling
  - Update all existing tests for new callback signature
  - All 272 tests passing

## Testing

**New TDD Tests**:
1. `should exit backoff when polling succeeds even if data callback throws` - Verifies Fix #1
2. `should increment lastFailureCount even when error callback throws` - Verifies Fix #2

**Test Results**:
- ✅ All 272 tests passing
- ✅ Coverage: 97.77% (mqtt-bridge), all metrics > 95%
- ✅ Both new regression tests pass (RED → GREEN cycle completed)

## Verification

- ✅ Lint: No errors
- ✅ Build: TypeScript compilation successful  
- ✅ Tests: 272/272 passing locally
- ✅ Coverage: All metrics > 95%
- ✅ Error handling: Polling state machine robust against callback exceptions
- ✅ Claude review: APPROVED

## CI Status

**Node 20.x Test Failure**: ⚠️ Unrelated flaky test in emulator package
- Test: `packages/emulator/src/behaviors/timing.integration.test.ts`
- Status: Tracked in #139
- Impact: Not related to changes in this PR (mqtt-bridge package)
- Evidence: Passes on Node 22.x and 24.x ✅

**Codecov**: Coverage metrics may show differences due to branch comparison, but local coverage is excellent (>95% all metrics)

## Related

Closes #93

Addresses user feedback from PR #90 review (comment on `index.ts:84`).
