### PR TITLE
feat(mqtt-bridge): add systemd service configuration for production deployments

### DIFF
--- a/packages/mqtt-bridge/systemd/ya-modbus-bridge.service
+++ b/packages/mqtt-bridge/systemd/ya-modbus-bridge.service
@@ -46,8 +46,9 @@ StateDirectoryMode=0750
 ProtectSystem=strict
 PrivateTmp=yes
 ProtectHome=yes
+PrivateDevices=yes
 NoExecPaths=/
-ExecPaths=/usr/bin /usr/local/bin /usr/lib /usr/local/lib
+ExecPaths=/usr/bin /usr/local/bin /usr/lib /usr/local/lib /lib /lib64
 
 # Security: Kernel Protection
 ProtectKernelLogs=true


### PR DESCRIPTION
## Summary

Adds production-ready systemd service configuration for running mqtt-bridge as a Linux system service with comprehensive security hardening and deployment documentation.

## What's Included

- **Systemd service file** (`ya-modbus-bridge.service`) with security best practices:
  - Process isolation and sandboxing (filesystem, kernel, namespace protection)
  - Resource limits (memory, CPU, file descriptors, tasks)
  - Network access restricted to IPv4/IPv6 for MQTT
  - System call filtering and capability restrictions
  - Automatic restart on failure with configurable delays
  - Journal integration for centralized logging
  - Documented version requirements (systemd v235 minimum, v247+ recommended)

- **Example configuration files**:
  - `config.json.example` - MQTT broker and bridge configuration template
  - `environment.example` - Environment variables template

- **Comprehensive installation guide** (`systemd/INSTALL.md`) covering:
  - Step-by-step installation instructions (10 steps)
  - Serial port access configuration for Modbus RTU/RS-485 users
  - Service management commands
  - Security analysis and hardening
  - Troubleshooting common issues
  - Advanced configuration (resource limits, multiple instances)
  - Update and uninstallation procedures

- **Updated README** with reference to systemd deployment

## Implementation Details

Based on industry best practices from systemd documentation and security hardening guides:
- Uses unprivileged system user with minimal permissions
- Implements defense-in-depth security (filesystem, kernel, process isolation)
- Follows principle of least privilege (no capabilities needed)
- Provides secure environment variable handling
- Includes graceful shutdown support (30s timeout)
- StateDirectory auto-creates state directory with correct ownership

## Compatibility

- **Minimum:** systemd v235
- **Recommended:** systemd v247+ (for full security features)
- Some security directives are silently ignored on older systemd versions

## Test Plan

- [ ] Verify service file syntax
- [ ] Test installation steps in documentation
- [ ] Validate security configuration with `systemd-analyze security`
- [ ] Confirm service starts, stops, and restarts correctly
- [ ] Test log output via journalctl
- [ ] Verify resource limits are applied