### PR TITLE
fix(release): add id-token permission for npm provenance generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ permissions:
   contents: write # For creating tags and pushing commits
   issues: write # For creating GitHub releases
   pull-requests: write # For release notes
+  id-token: write # For npm provenance generation
 
 jobs:
   release:


### PR DESCRIPTION
## Problem

After fixing the recursive lerna invocation issue in #142, the release workflow now fails at the npm publish step with:

```
Error: Provenance generation in GitHub Actions requires "write" access to the "id-token" permission
```

This error occurs because npm provenance generation is enabled (`NPM_CONFIG_PROVENANCE: true` in the workflow), but the workflow lacks the required `id-token: write` permission.

## Solution

Added `id-token: write` to the workflow permissions.

## What is npm provenance?

npm provenance provides supply chain security by:
- Cryptographically linking published packages to their source repository
- Linking packages to the specific build environment and workflow
- Allowing users to verify package authenticity
- Improving transparency in the software supply chain

See: https://docs.npmjs.com/generating-provenance-statements

## Verification

- ✅ Single line change to workflow permissions
- ✅ No behavior changes to existing functionality
- ✅ Enables secure package publishing with provenance

## References

Related to #142 (recursive lerna invocation fix)