### PR TITLE
fix(release): use proper commit message for independent versioning

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -7,7 +7,7 @@
       "conventionalCommits": true,
       "changelogPreset": "angular",
       "createRelease": "github",
-      "message": "chore(release): publish %s",
+      "message": "chore(release): publish packages",
       "ignoreChanges": [
         "**/__tests__/**",
         "**/*.test.ts",


### PR DESCRIPTION
## Problem

The lerna version commit had message `chore(release): publish %s` where the `%s` placeholder was not replaced:

```
commit de2caa9
Author: github-actions[bot]
Date:   Sun Jan 4 07:36:15 2026 +0000

    chore(release): publish %s
```

The `%s` placeholder in lerna's message template is designed for fixed versioning mode where all packages share the same version. With independent versioning, each package has its own version, so there's no single version to substitute.

## Solution

Changed the commit message template from:
```json
"message": "chore(release): publish %s"
```

To:
```json
"message": "chore(release): publish packages"
```

This is appropriate for independent versioning. The commit body still contains the complete list of packages and their specific versions:

```
- @ya-modbus/cli@0.1.0
- @ya-modbus/device-profiler@0.2.0
- ...
```

## Verification

- ✅ Message is clear and follows conventional commits
- ✅ No placeholder that won't be substituted
- ✅ Commit body still contains detailed package version list
- ✅ Appropriate for independent versioning strategy

## References

- Lerna-Lite documentation on message templates
- Current versioning mode: independent (lerna.json line 3)