### PR TITLE
fix(release): disable provenance and sync workspace lock

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,7 @@ jobs:
           TAGS_BEFORE=$(git tag | wc -l)
 
           # Run lerna version (exits 0 even if no changes)
-          npx lerna version --yes --no-private || EXIT_CODE=$?
+          npx lerna version --yes --no-private --sync-workspace-lock || EXIT_CODE=$?
 
           # Check if any new tags were created
           TAGS_AFTER=$(git tag | wc -l)
@@ -195,7 +195,8 @@ jobs:
             --no-git-tag-version \
             --no-push \
             --yes \
-            --no-private
+            --no-private \
+            --sync-workspace-lock
 
       - name: Check for version conflicts (pre-release)
         if: steps.release-type.outputs.is_prerelease == 'true' && steps.release-type.outputs.is_dry_run == 'false'
@@ -250,7 +251,6 @@ jobs:
         run: npx lerna publish from-git --yes --no-private
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
 
       - name: No changes detected
         if: |
@@ -276,7 +276,6 @@ jobs:
             --no-private
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
 
       - name: Find PR for this branch
         if: steps.release-type.outputs.is_prerelease == 'true' && steps.release-type.outputs.is_dry_run == 'false'


### PR DESCRIPTION
## Problem

The previous release attempt (#145) succeeded in creating versions and tags but **failed to publish to npm** with error:

```
E422 Error verifying sigstore provenance bundle: Unsupported GitHub Actions source 
repository visibility: "private". Only public source repositories are supported when 
publishing with provenance.
```

Additionally, lerna was issuing a warning:
```
WARN npm we recommend using --sync-workspace-lock
```

## Solution

This PR fixes both issues:

### 1. Disable npm Provenance Generation

**What:** Removed `NPM_CONFIG_PROVENANCE: true` from both production and pre-release publish steps

**Why:** npm provenance only works for public repositories. This repository is private, so provenance generation fails with 422 errors.

**Reference:** https://docs.npmjs.com/generating-provenance-statements

### 2. Add --sync-workspace-lock Flag

**What:** Added `--sync-workspace-lock` to both `lerna version` commands (production and pre-release)

**Why:** 
- Uses npm to update `package-lock.json` instead of lerna doing it internally
- More reliable and future-proof (lerna doesn't need to track npm's lock file format changes)
- Eliminates the warning message

**Reference:** [lerna-lite/lerna-lite#877](https://github.com/lerna-lite/lerna-lite/issues/877)

## Cleanup Already Done ✅

Before pushing this PR, the failed release was cleaned up:
- ✅ Deleted 10 GitHub releases (all @0.1.0 from failed run)
- ✅ Git tags remain deleted from previous cleanup

## What Happens After Merge

When this PR merges:

1. ✅ Automated workflow triggers (push to main)
2. ✅ Lerna versions packages (0.0.0 → 0.1.0)
3. ✅ Tags and releases created  
4. ✅ **Packages successfully published to npm** (no provenance errors)
5. ✅ Lock file properly synced (no warnings)

## Changes

- Removed `NPM_CONFIG_PROVENANCE: true` from 2 publish steps
- Added `--sync-workspace-lock` flag to 2 version commands

## Verification

- ✅ All packages at version 0.0.0 (ready for fresh release)
- ✅ No git tags exist
- ✅ No GitHub releases exist
- ✅ Workflow has all necessary permissions
- ✅ Private repo limitation addressed

---

### Sources:
- [npm provenance documentation](https://docs.npmjs.com/generating-provenance-statements)
- [lerna-lite --sync-workspace-lock feature](https://github.com/lerna-lite/lerna-lite/releases/tag/v1.5.0)
- [Issue about sync-workspace-lock](https://github.com/lerna-lite/lerna-lite/issues/877)