### PR TITLE
fix(release): bump versions to 0.2.0 to bypass npm 24h block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11855,12 +11855,12 @@
     },
     "packages/cli": {
       "name": "@ya-modbus/cli",
-      "version": "0.0.0",
+      "version": "0.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@ya-modbus/driver-loader": "^0.0.0",
-        "@ya-modbus/driver-types": "^0.0.0",
-        "@ya-modbus/transport": "^0.0.0",
+        "@ya-modbus/driver-loader": "^0.2.0",
+        "@ya-modbus/driver-types": "^0.2.0",
+        "@ya-modbus/transport": "^0.2.0",
         "chalk": "^5.3.0",
         "cli-table3": "^0.6.3",
         "commander": "^14.0.2"
@@ -11892,11 +11892,11 @@
     },
     "packages/device-profiler": {
       "name": "@ya-modbus/device-profiler",
-      "version": "0.0.0",
+      "version": "0.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@ya-modbus/driver-types": "^0.0.0",
-        "@ya-modbus/transport": "^0.0.0",
+        "@ya-modbus/driver-types": "^0.2.0",
+        "@ya-modbus/transport": "^0.2.0",
         "chalk": "^5.3.0",
         "cli-table3": "^0.6.3",
         "commander": "^14.0.2"
@@ -11928,10 +11928,10 @@
     },
     "packages/driver-loader": {
       "name": "@ya-modbus/driver-loader",
-      "version": "0.0.0",
+      "version": "0.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@ya-modbus/driver-types": "^0.0.0"
+        "@ya-modbus/driver-types": "^0.2.0"
       },
       "peerDependencies": {
         "jest": ">=29.0.0"
@@ -11944,20 +11944,20 @@
     },
     "packages/driver-sdk": {
       "name": "@ya-modbus/driver-sdk",
-      "version": "0.0.0",
+      "version": "0.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@ya-modbus/driver-types": "^0.0.0"
+        "@ya-modbus/driver-types": "^0.2.0"
       }
     },
     "packages/driver-types": {
       "name": "@ya-modbus/driver-types",
-      "version": "0.0.0",
+      "version": "0.2.0",
       "license": "GPL-3.0-or-later"
     },
     "packages/emulator": {
       "name": "@ya-modbus/emulator",
-      "version": "0.0.0",
+      "version": "0.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "commander": "^12.1.0",
@@ -11982,12 +11982,12 @@
     },
     "packages/mqtt-bridge": {
       "name": "@ya-modbus/mqtt-bridge",
-      "version": "0.0.0",
+      "version": "0.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@ya-modbus/driver-loader": "^0.0.0",
-        "@ya-modbus/driver-types": "^0.0.0",
-        "@ya-modbus/transport": "^0.0.0",
+        "@ya-modbus/driver-loader": "^0.2.0",
+        "@ya-modbus/driver-types": "^0.2.0",
+        "@ya-modbus/transport": "^0.2.0",
         "chalk": "^5.6.2",
         "commander": "^14.0.2",
         "mqtt": "^5.14.1",
@@ -12021,10 +12021,10 @@
     },
     "packages/transport": {
       "name": "@ya-modbus/transport",
-      "version": "0.0.0",
+      "version": "0.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@ya-modbus/driver-types": "^0.0.0",
+        "@ya-modbus/driver-types": "^0.2.0",
         "async-mutex": "^0.5.0",
         "modbus-serial": "^8.0.18"
       }
@@ -12033,22 +12033,22 @@
       "version": "0.0.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@ya-modbus/driver-sdk": "^0.0.0",
-        "@ya-modbus/driver-types": "^0.0.0"
+        "@ya-modbus/driver-sdk": "^0.2.0",
+        "@ya-modbus/driver-types": "^0.2.0"
       },
       "devDependencies": {
-        "@ya-modbus/cli": "^0.0.0"
+        "@ya-modbus/cli": "^0.2.0"
       }
     },
     "packages/ya-modbus-driver-xymd1": {
       "version": "0.0.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@ya-modbus/driver-sdk": "^0.0.0",
-        "@ya-modbus/driver-types": "^0.0.0"
+        "@ya-modbus/driver-sdk": "^0.2.0",
+        "@ya-modbus/driver-types": "^0.2.0"
       },
       "devDependencies": {
-        "@ya-modbus/cli": "^0.0.0"
+        "@ya-modbus/cli": "^0.2.0"
       }
     }
   }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.2.0](https://github.com/groupsky/ya-modbus/compare/@ya-modbus/cli@0.1.0...@ya-modbus/cli@0.2.0) (2026-01-04)
+
+### Bug Fixes
+
+- **release:** revert failed release and add missing publishConfig ([#147](https://github.com/groupsky/ya-modbus/issues/147)) ([8cbd4ba](https://github.com/groupsky/ya-modbus/commit/8cbd4baf9c140c8ef10080947ddd566014f32c77))
+
+### Reverts
+
+- Revert "chore(release): publish packages" ([b0b722e](https://github.com/groupsky/ya-modbus/commit/b0b722e686f0466b2e2c58df4b1539a634b0fe12))
+- Revert "chore(release): publish packages" ([b613837](https://github.com/groupsky/ya-modbus/commit/b6138375978fdebfd57e645367f3fc8011f0452f))

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ya-modbus/cli",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "description": "CLI tool for testing and developing Modbus device drivers",
   "type": "module",
   "keywords": [
@@ -44,17 +44,17 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "@ya-modbus/driver-loader": "^0.0.0",
-    "@ya-modbus/driver-types": "^0.0.0",
-    "@ya-modbus/transport": "^0.0.0",
-    "commander": "^14.0.2",
+    "@ya-modbus/driver-loader": "^0.2.0",
+    "@ya-modbus/driver-types": "^0.2.0",
+    "@ya-modbus/transport": "^0.2.0",
     "chalk": "^5.3.0",
-    "cli-table3": "^0.6.3"
+    "cli-table3": "^0.6.3",
+    "commander": "^14.0.2"
   },
   "devDependencies": {
     "@types/node": "^20.10.6",
-    "typescript": "^5.7.2",
     "jest": "^30.2.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.7.2"
   }
 }

--- a/packages/device-profiler/CHANGELOG.md
+++ b/packages/device-profiler/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.2.0](https://github.com/groupsky/ya-modbus/compare/@ya-modbus/device-profiler@0.1.0...@ya-modbus/device-profiler@0.2.0) (2026-01-04)
+
+### Bug Fixes
+
+- **release:** revert failed release and add missing publishConfig ([#147](https://github.com/groupsky/ya-modbus/issues/147)) ([8cbd4ba](https://github.com/groupsky/ya-modbus/commit/8cbd4baf9c140c8ef10080947ddd566014f32c77))
+
+### Reverts
+
+- Revert "chore(release): publish packages" ([b0b722e](https://github.com/groupsky/ya-modbus/commit/b0b722e686f0466b2e2c58df4b1539a634b0fe12))
+- Revert "chore(release): publish packages" ([b613837](https://github.com/groupsky/ya-modbus/commit/b6138375978fdebfd57e645367f3fc8011f0452f))

--- a/packages/device-profiler/package.json
+++ b/packages/device-profiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ya-modbus/device-profiler",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "description": "Device profiler for discovering Modbus register maps",
   "license": "GPL-3.0-or-later",
   "type": "module",
@@ -44,16 +44,16 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "@ya-modbus/driver-types": "^0.0.0",
-    "@ya-modbus/transport": "^0.0.0",
-    "commander": "^14.0.2",
+    "@ya-modbus/driver-types": "^0.2.0",
+    "@ya-modbus/transport": "^0.2.0",
     "chalk": "^5.3.0",
-    "cli-table3": "^0.6.3"
+    "cli-table3": "^0.6.3",
+    "commander": "^14.0.2"
   },
   "devDependencies": {
     "@types/node": "^20.10.6",
-    "typescript": "^5.7.2",
     "jest": "^30.2.0",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.7.2"
   }
 }

--- a/packages/driver-loader/CHANGELOG.md
+++ b/packages/driver-loader/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.2.0](https://github.com/groupsky/ya-modbus/compare/@ya-modbus/driver-loader@0.1.0...@ya-modbus/driver-loader@0.2.0) (2026-01-04)
+
+### Bug Fixes
+
+- **release:** revert failed release and add missing publishConfig ([#147](https://github.com/groupsky/ya-modbus/issues/147)) ([8cbd4ba](https://github.com/groupsky/ya-modbus/commit/8cbd4baf9c140c8ef10080947ddd566014f32c77))
+
+### Reverts
+
+- Revert "chore(release): publish packages" ([b0b722e](https://github.com/groupsky/ya-modbus/commit/b0b722e686f0466b2e2c58df4b1539a634b0fe12))
+- Revert "chore(release): publish packages" ([b613837](https://github.com/groupsky/ya-modbus/commit/b6138375978fdebfd57e645367f3fc8011f0452f))

--- a/packages/driver-loader/package.json
+++ b/packages/driver-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ya-modbus/driver-loader",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "description": "Dynamic driver loader for ya-modbus device drivers",
   "keywords": [
     "modbus",
@@ -44,7 +44,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@ya-modbus/driver-types": "^0.0.0"
+    "@ya-modbus/driver-types": "^0.2.0"
   },
   "peerDependencies": {
     "jest": ">=29.0.0"

--- a/packages/driver-sdk/CHANGELOG.md
+++ b/packages/driver-sdk/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.2.0](https://github.com/groupsky/ya-modbus/compare/@ya-modbus/driver-sdk@0.1.0...@ya-modbus/driver-sdk@0.2.0) (2026-01-04)
+
+### Bug Fixes
+
+- **release:** revert failed release and add missing publishConfig ([#147](https://github.com/groupsky/ya-modbus/issues/147)) ([8cbd4ba](https://github.com/groupsky/ya-modbus/commit/8cbd4baf9c140c8ef10080947ddd566014f32c77))
+
+### Reverts
+
+- Revert "chore(release): publish packages" ([b0b722e](https://github.com/groupsky/ya-modbus/commit/b0b722e686f0466b2e2c58df4b1539a634b0fe12))
+- Revert "chore(release): publish packages" ([b613837](https://github.com/groupsky/ya-modbus/commit/b6138375978fdebfd57e645367f3fc8011f0452f))

--- a/packages/driver-sdk/package.json
+++ b/packages/driver-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ya-modbus/driver-sdk",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "description": "Runtime SDK for ya-modbus device drivers with transformation utilities and helpers",
   "keywords": [
     "modbus",
@@ -34,6 +34,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "@ya-modbus/driver-types": "^0.0.0"
+    "@ya-modbus/driver-types": "^0.2.0"
   }
 }

--- a/packages/driver-types/CHANGELOG.md
+++ b/packages/driver-types/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.2.0](https://github.com/groupsky/ya-modbus/compare/@ya-modbus/driver-types@0.1.0...@ya-modbus/driver-types@0.2.0) (2026-01-04)
+
+### Bug Fixes
+
+- **release:** revert failed release and add missing publishConfig ([#147](https://github.com/groupsky/ya-modbus/issues/147)) ([8cbd4ba](https://github.com/groupsky/ya-modbus/commit/8cbd4baf9c140c8ef10080947ddd566014f32c77))
+
+### Reverts
+
+- Revert "chore(release): publish packages" ([b0b722e](https://github.com/groupsky/ya-modbus/commit/b0b722e686f0466b2e2c58df4b1539a634b0fe12))
+- Revert "chore(release): publish packages" ([b613837](https://github.com/groupsky/ya-modbus/commit/b6138375978fdebfd57e645367f3fc8011f0452f))

--- a/packages/driver-types/package.json
+++ b/packages/driver-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ya-modbus/driver-types",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "description": "TypeScript type definitions for ya-modbus device drivers",
   "keywords": [
     "modbus",

--- a/packages/emulator/CHANGELOG.md
+++ b/packages/emulator/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.2.0](https://github.com/groupsky/ya-modbus/compare/@ya-modbus/emulator@0.1.0...@ya-modbus/emulator@0.2.0) (2026-01-04)
+
+### Bug Fixes
+
+- **release:** revert failed release and add missing publishConfig ([#147](https://github.com/groupsky/ya-modbus/issues/147)) ([8cbd4ba](https://github.com/groupsky/ya-modbus/commit/8cbd4baf9c140c8ef10080947ddd566014f32c77))
+
+### Reverts
+
+- Revert "chore(release): publish packages" ([b0b722e](https://github.com/groupsky/ya-modbus/commit/b0b722e686f0466b2e2c58df4b1539a634b0fe12))
+- Revert "chore(release): publish packages" ([b613837](https://github.com/groupsky/ya-modbus/commit/b6138375978fdebfd57e645367f3fc8011f0452f))

--- a/packages/emulator/package.json
+++ b/packages/emulator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ya-modbus/emulator",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "description": "Software Modbus device emulator for testing drivers without physical hardware",
   "keywords": [
     "modbus",
@@ -38,9 +38,9 @@
     "test": "jest"
   },
   "dependencies": {
-    "modbus-serial": "^8.0.23",
     "commander": "^12.1.0",
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.1.0",
+    "modbus-serial": "^8.0.23"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9"

--- a/packages/mqtt-bridge/CHANGELOG.md
+++ b/packages/mqtt-bridge/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.2.0](https://github.com/groupsky/ya-modbus/compare/@ya-modbus/mqtt-bridge@0.1.0...@ya-modbus/mqtt-bridge@0.2.0) (2026-01-04)
+
+### Bug Fixes
+
+- **release:** revert failed release and add missing publishConfig ([#147](https://github.com/groupsky/ya-modbus/issues/147)) ([8cbd4ba](https://github.com/groupsky/ya-modbus/commit/8cbd4baf9c140c8ef10080947ddd566014f32c77))
+
+### Reverts
+
+- Revert "chore(release): publish packages" ([b0b722e](https://github.com/groupsky/ya-modbus/commit/b0b722e686f0466b2e2c58df4b1539a634b0fe12))
+- Revert "chore(release): publish packages" ([b613837](https://github.com/groupsky/ya-modbus/commit/b6138375978fdebfd57e645367f3fc8011f0452f))

--- a/packages/mqtt-bridge/package.json
+++ b/packages/mqtt-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ya-modbus/mqtt-bridge",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "description": "MQTT bridge for ya-modbus - orchestrates device management, polling, and MQTT publishing",
   "keywords": [
     "modbus",
@@ -43,9 +43,9 @@
     "prepublishOnly": "npm run build && chmod +x dist/bin/ya-modbus-bridge.js"
   },
   "dependencies": {
-    "@ya-modbus/driver-loader": "^0.0.0",
-    "@ya-modbus/driver-types": "^0.0.0",
-    "@ya-modbus/transport": "^0.0.0",
+    "@ya-modbus/driver-loader": "^0.2.0",
+    "@ya-modbus/driver-types": "^0.2.0",
+    "@ya-modbus/transport": "^0.2.0",
     "chalk": "^5.6.2",
     "commander": "^14.0.2",
     "mqtt": "^5.14.1",

--- a/packages/transport/CHANGELOG.md
+++ b/packages/transport/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.2.0](https://github.com/groupsky/ya-modbus/compare/@ya-modbus/transport@0.1.0...@ya-modbus/transport@0.2.0) (2026-01-04)
+
+### Bug Fixes
+
+- **release:** revert failed release and add missing publishConfig ([#147](https://github.com/groupsky/ya-modbus/issues/147)) ([8cbd4ba](https://github.com/groupsky/ya-modbus/commit/8cbd4baf9c140c8ef10080947ddd566014f32c77))
+
+### Reverts
+
+- Revert "chore(release): publish packages" ([b0b722e](https://github.com/groupsky/ya-modbus/commit/b0b722e686f0466b2e2c58df4b1539a634b0fe12))
+- Revert "chore(release): publish packages" ([b613837](https://github.com/groupsky/ya-modbus/commit/b6138375978fdebfd57e645367f3fc8011f0452f))

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ya-modbus/transport",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "description": "Modbus transport implementations for ya-modbus",
   "keywords": [
     "modbus",
@@ -38,7 +38,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@ya-modbus/driver-types": "^0.0.0",
+    "@ya-modbus/driver-types": "^0.2.0",
     "async-mutex": "^0.5.0",
     "modbus-serial": "^8.0.18"
   }

--- a/packages/ya-modbus-driver-ex9em/CHANGELOG.md
+++ b/packages/ya-modbus-driver-ex9em/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.2.0](https://github.com/groupsky/ya-modbus/compare/ya-modbus-driver-ex9em@0.1.0...ya-modbus-driver-ex9em@0.2.0) (2026-01-04)
+
+### Bug Fixes
+
+- **release:** revert failed release and add missing publishConfig ([#147](https://github.com/groupsky/ya-modbus/issues/147)) ([8cbd4ba](https://github.com/groupsky/ya-modbus/commit/8cbd4baf9c140c8ef10080947ddd566014f32c77))
+
+### Reverts
+
+- Revert "chore(release): publish packages" ([b0b722e](https://github.com/groupsky/ya-modbus/commit/b0b722e686f0466b2e2c58df4b1539a634b0fe12))
+- Revert "chore(release): publish packages" ([b613837](https://github.com/groupsky/ya-modbus/commit/b6138375978fdebfd57e645367f3fc8011f0452f))

--- a/packages/ya-modbus-driver-ex9em/package.json
+++ b/packages/ya-modbus-driver-ex9em/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ya-modbus-driver-ex9em",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "description": "NOARK Ex9EM Energy Meter driver for ya-modbus",
   "keywords": [
     "modbus",
@@ -40,10 +40,10 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@ya-modbus/driver-sdk": "^0.0.0",
-    "@ya-modbus/driver-types": "^0.0.0"
+    "@ya-modbus/driver-sdk": "^0.2.0",
+    "@ya-modbus/driver-types": "^0.2.0"
   },
   "devDependencies": {
-    "@ya-modbus/cli": "^0.0.0"
+    "@ya-modbus/cli": "^0.2.0"
   }
 }

--- a/packages/ya-modbus-driver-xymd1/CHANGELOG.md
+++ b/packages/ya-modbus-driver-xymd1/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.2.0](https://github.com/groupsky/ya-modbus/compare/ya-modbus-driver-xymd1@0.1.0...ya-modbus-driver-xymd1@0.2.0) (2026-01-04)
+
+### Bug Fixes
+
+- **release:** revert failed release and add missing publishConfig ([#147](https://github.com/groupsky/ya-modbus/issues/147)) ([8cbd4ba](https://github.com/groupsky/ya-modbus/commit/8cbd4baf9c140c8ef10080947ddd566014f32c77))
+
+### Reverts
+
+- Revert "chore(release): publish packages" ([b0b722e](https://github.com/groupsky/ya-modbus/commit/b0b722e686f0466b2e2c58df4b1539a634b0fe12))
+- Revert "chore(release): publish packages" ([b613837](https://github.com/groupsky/ya-modbus/commit/b6138375978fdebfd57e645367f3fc8011f0452f))

--- a/packages/ya-modbus-driver-xymd1/package.json
+++ b/packages/ya-modbus-driver-xymd1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ya-modbus-driver-xymd1",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "description": "XYMD1 Temperature and Humidity Sensor driver for ya-modbus",
   "keywords": [
     "modbus",
@@ -38,10 +38,10 @@
     "test": "jest"
   },
   "dependencies": {
-    "@ya-modbus/driver-sdk": "^0.0.0",
-    "@ya-modbus/driver-types": "^0.0.0"
+    "@ya-modbus/driver-sdk": "^0.2.0",
+    "@ya-modbus/driver-types": "^0.2.0"
   },
   "devDependencies": {
-    "@ya-modbus/cli": "^0.0.0"
+    "@ya-modbus/cli": "^0.2.0"
   }
 }


### PR DESCRIPTION
## Summary

- Reverts failed release commit c792634 that set versions to 0.1.0
- Bumps all packages to 0.2.0 to bypass npm's 24-hour republish policy

The previous release attempts partially published some packages at 0.1.0, which were then unpublished. npm blocks republishing the same version for 24 hours after unpublish, so we skip to 0.2.0.

## Test plan

- [ ] Merge PR
- [ ] Verify release workflow succeeds and publishes all 10 packages at 0.2.0