### PR TITLE
docs: update stale documentation after release and public readiness changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.0+-blue.svg)](https://www.typescriptlang.org/)
-[![Node](https://img.shields.io/badge/Node-24+-green.svg)](https://nodejs.org/)
+[![Node](https://img.shields.io/badge/Node-20+-green.svg)](https://nodejs.org/)
 [![codecov](https://codecov.io/gh/groupsky/ya-modbus/graph/badge.svg)](https://codecov.io/gh/groupsky/ya-modbus)
 
 ## Features
@@ -16,7 +16,6 @@
 - **Multi-register optimization** - Batch adjacent registers (70-90% fewer operations)
 - **Production monitoring** - Comprehensive diagnostics, error publishing, health checks
 - **RTU & TCP support** - Serial (RS-485/RS-232) and network Modbus devices
-- **Converter ecosystem** - Optional data normalization for InfluxDB, Prometheus, PostgreSQL
 - **Software emulator** - Test device drivers without physical hardware
 - **Agent-friendly** - Comprehensive documentation, per-directory guides for AI assistants
 
@@ -25,7 +24,7 @@
 ### Installation
 
 ```bash
-npm install -g ya-modbus
+npm install -g @ya-modbus/cli
 ```
 
 ### Basic Usage
@@ -178,7 +177,7 @@ Device drivers can be distributed as independent npm packages:
 
 ```bash
 # Install bridge + third-party driver
-npm install -g ya-modbus ya-modbus-driver-solar
+npm install -g @ya-modbus/cli ya-modbus-driver-solar
 
 # Use in configuration
 {
@@ -191,7 +190,10 @@ npm install -g ya-modbus ya-modbus-driver-solar
 }
 ```
 
-**Recommended naming**: `ya-modbus-driver-<name>` for easy discovery
+**Naming conventions**:
+
+- Monorepo packages: `@ya-modbus/driver-<name>` (e.g., `@ya-modbus/driver-ex9em`)
+- Third-party packages: `ya-modbus-driver-<name>` for easy discovery
 
 **Auto-detection**: Drivers can auto-detect device model when `deviceType` is omitted
 
@@ -221,7 +223,7 @@ npm install -g ya-modbus ya-modbus-driver-solar
 
 ### Prerequisites
 
-- Node.js 24+ (see `.nvmrc`)
+- Node.js 20+ (see `.nvmrc`)
 - npm 10+
 
 ### Setup
@@ -248,12 +250,15 @@ npm run dev
 
 ```
 packages/
-├── core/         # Bridge orchestration, transport, polling, discovery
-├── cli/          # Command-line tool (test, provision, monitor)
-├── devices/      # Device-specific implementations
-├── converters/   # Data normalization layer (optional companion)
-├── emulator/     # Software Modbus device emulator for testing
-└── mqtt-config/  # Runtime configuration management
+├── mqtt-bridge/      # Bridge orchestration, MQTT publishing, polling
+├── cli/              # Command-line tool (test, provision, monitor)
+├── transport/        # RTU/TCP transport implementations
+├── driver-types/     # TypeScript type definitions
+├── driver-sdk/       # Runtime SDK for driver development
+├── driver-loader/    # Dynamic driver loading
+├── device-profiler/  # Device discovery and register scanning
+├── emulator/         # Software Modbus device emulator for testing
+└── driver-*/         # Device drivers (e.g., driver-ex9em, driver-xymd1)
 ```
 
 ## Runtime Configuration via MQTT
@@ -368,36 +373,6 @@ services:
       STATE_FILE: /data/bridge-state.json
     restart: unless-stopped
 ```
-
-## Companion Package: modbus-herdsman-converters
-
-Optional data normalization layer inspired by zigbee-herdsman-converters:
-
-```typescript
-import { convert } from '@ya-modbus/converters'
-
-// Raw device data
-const rawData = {
-  voltage: 230.5,
-  current: 5.2,
-  power: 1198.6,
-}
-
-// Convert to InfluxDB format
-const influx = convert(rawData, {
-  adapter: 'influxdb',
-  measurement: 'modbus_device',
-  tags: { device_id: 'meter_1', location: 'building_a' },
-})
-
-// Convert to Prometheus format
-const prometheus = convert(rawData, {
-  adapter: 'prometheus',
-  prefix: 'modbus',
-})
-```
-
-See [@ya-modbus/converters](./packages/converters/README.md) for details.
 
 ## Performance
 

--- a/docs/NEW-PACKAGE.md
+++ b/docs/NEW-PACKAGE.md
@@ -61,7 +61,7 @@ module.exports = {
 
 **REQUIRED**: All new packages must set minimum coverage thresholds of **95%** for branches, functions, lines, and statements. This ensures high test quality and prevents regressions.
 
-See `packages/cli/jest.config.cjs` or `packages/ya-modbus-driver-xymd1/jest.config.cjs` for reference.
+See `packages/cli/jest.config.cjs` or `packages/driver-xymd1/jest.config.cjs` for reference.
 
 ### 3. AGENTS.md
 
@@ -149,6 +149,18 @@ Packages typically extend the base tsconfig:
 }
 ```
 
+### Engine Requirements
+
+All packages MUST specify the Node.js engine requirement:
+
+```json
+{
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}
+```
+
 ### Module Resolution
 
 For ESM packages, set in package.json:
@@ -175,7 +187,9 @@ Reference other workspace packages:
 
 ### Driver Package
 
-Device driver packages should follow naming: `ya-modbus-driver-<device>`
+Device driver packages use scoped naming: `@ya-modbus/driver-<device>`
+
+The package folder should be named `driver-<device>` (e.g., `packages/driver-xymd1`).
 
 **Required exports**:
 
@@ -273,7 +287,7 @@ describe('Configuration consistency', () => {
 
 This pattern ensures the factory defaults are always valid according to the device's supported values.
 
-See `packages/ya-modbus-driver-xymd1` for reference implementation.
+See `packages/driver-xymd1` for reference implementation.
 
 ### Utility Package
 

--- a/docs/agents/driver-development.md
+++ b/docs/agents/driver-development.md
@@ -1,5 +1,5 @@
 ---
-paths: packages/ya-modbus-driver-*/**/*.ts
+paths: packages/driver-*/**/*.ts
 ---
 
 # Driver Development Guidelines
@@ -27,12 +27,12 @@ See: `packages/driver-sdk/src/codec.ts` for buffer transformation functions
 See: `packages/driver-sdk/src/validators.ts` for configuration validators
 See: `packages/driver-sdk/src/errors.ts` for error formatting
 See: `packages/driver-sdk/README.md` for API reference
-See: `packages/ya-modbus-driver-ex9em/src/device.ts` for usage examples
+See: `packages/driver-ex9em/src/device.ts` for usage examples
 
 ## Naming Conventions
 
-- Package: `ya-modbus-driver-<name>` (e.g., `ya-modbus-driver-solar`)
-- Scoped: `@org/ya-modbus-driver-<name>`
+- Package: `@ya-modbus/driver-<name>` (e.g., `@ya-modbus/driver-ex9em`)
+- Third-party: `@org/ya-modbus-driver-<name>` or `ya-modbus-driver-<name>`
 - Data points: semantic, not `reg_0000` or `holding_6`
 - Units: canonical from driver-sdk (`V` not `volts`)
 
@@ -60,7 +60,7 @@ If exporting configs, add cross-validation tests:
 
 ## Testing
 
-- Emulator for fast iteration (`@ya-modbus/driver-dev-tools`)
+- Emulator for fast iteration (`@ya-modbus/emulator`)
 - Real device testing via `npx ya-modbus` commands
 - Test both explicit device type and auto-detection
 
@@ -69,7 +69,7 @@ If exporting configs, add cross-validation tests:
 - `src/index.ts` - Export `createDriver` function
 - `src/device.ts` - Driver implementation
 - `src/device.test.ts` - Tests
-- `package.json` - Must include `"ya-modbus-driver"` in keywords
+- `package.json` - Must include `"ya-modbus-driver"` in keywords and `engines` field
 
 See: `docs/DRIVER-DEVELOPMENT.md` for complete guide
-See: `packages/ya-modbus-driver-*/` for reference implementations
+See: `packages/driver-*/` for reference implementations

--- a/docs/agents/package-creation.md
+++ b/docs/agents/package-creation.md
@@ -23,7 +23,7 @@ Every new package MUST include:
 
 All packages require 95% coverage (branches, functions, lines, statements).
 
-See: `packages/ya-modbus-driver-xymd1/jest.config.cjs:23-30` for required `coverageThreshold` configuration.
+See: `packages/driver-xymd1/jest.config.cjs:23-30` for required `coverageThreshold` configuration.
 
 ### Root Configuration Updates
 
@@ -38,8 +38,19 @@ See: Root `tsconfig.lint-base.json:19-27` for paths format
 
 ### Naming Patterns
 
-- Drivers: `ya-modbus-driver-<device>`
-- Utilities: `@ya-modbus/<name>`
+- All packages: `@ya-modbus/<name>` (scoped naming)
+- Driver folders: `packages/driver-<device>`
+- Driver package names: `@ya-modbus/driver-<device>`
+
+### Engines Field
+
+All packages MUST include the engines field:
+
+```json
+"engines": {
+  "node": ">=20.0.0"
+}
+```
 
 ## Driver Packages
 
@@ -59,5 +70,5 @@ Before committing:
 
 - Comprehensive guide: docs/NEW-PACKAGE.md
 - Driver development: docs/agents/driver-development.md
-- Driver reference: packages/ya-modbus-driver-xymd1
+- Driver reference: packages/driver-xymd1
 - CLI reference: packages/cli

--- a/docs/agents/release.md
+++ b/docs/agents/release.md
@@ -4,7 +4,7 @@ paths: /lerna.json, /.github/workflows/release.yml
 
 # Release Process Guidelines
 
-Publishing packages to npm using Lerna-Lite with conventional commits.
+Publishing packages to npm using Lerna-Lite with conventional commits. Uses npm trusted publishers with OIDC for secure, tokenless publishing with provenance.
 
 ## Release Triggers
 
@@ -48,8 +48,7 @@ NEVER use npm scripts named `version` or `publish` - they conflict with npm life
 
 Use npx lerna commands directly with `--yes` and `--no-private` flags.
 
-See: `.github/workflows/release.yml` lines 172-173, 249 for production commands
-See: `.github/workflows/release.yml` lines 192-197, 271-276 for pre-release commands
+See: `.github/workflows/release.yml` "Version packages" and "Publish to npm" steps
 See: `docs/PUBLISHING-SETUP.md` for complete manual release procedure
 See: `lerna.json` for Lerna configuration
 See: `docs/agents/git.md` for commit message format

--- a/docs/agents/workflows.md
+++ b/docs/agents/workflows.md
@@ -14,8 +14,20 @@ See: `.github/workflows/ci.yml` for matrix generation implementation
 
 ## Release Workflows
 
-For release and publishing workflows, see dedicated documentation.
+Uses npm trusted publishers with OIDC for secure publishing. Requires `id-token: write` permission and `npm` environment.
 
 See: `docs/agents/release.md` for release process
 See: `.github/workflows/release.yml` for production/pre-release workflow
 See: `.github/workflows/cleanup-prerelease.yml` for dist-tag cleanup
+
+## Claude Workflows
+
+Two workflows for Claude Code integration with security hardening.
+
+### Security Measures
+
+- **Fork PR skip**: `claude-code-review.yml` skips fork PRs to prevent prompt injection
+- **Tool restrictions**: Both workflows use `--allowed-tools` to limit Claude to safe operations
+
+See: `.github/workflows/claude.yml` for issue/comment responses
+See: `.github/workflows/claude-code-review.yml` for automated PR reviews


### PR DESCRIPTION
## Summary

- Update documentation to reflect current package structure and naming conventions
- Replace NPM_TOKEN authentication with OIDC trusted publishers
- Fix stale package references throughout documentation

## Changes

### Publishing & Release
- **PUBLISHING-SETUP.md**: Replace NPM_TOKEN with OIDC trusted publishers setup
- **release.md**: Add OIDC/provenance mention, fix fragile line number references
- **workflows.md**: Add Claude workflows security section, document OIDC requirements

### Package Structure & Naming
- **README.md**: Fix Node version badge (20+), update install command to `@ya-modbus/cli`, update project structure to actual packages
- **ARCHITECTURE.md**: Update package structure (`@ya-modbus/mqtt-bridge`, `driver-*`, `device-profiler`, `driver-loader`)
- **DRIVER-DEVELOPMENT.md**: Fix paths to `packages/driver-*`, update naming conventions, replace `driver-dev-tools` with `emulator`
- **NEW-PACKAGE.md**: Add engines field requirement, fix package references
- **package-creation.md**: Update naming patterns, add engines requirement
- **driver-development.md** (agents): Fix paths and package references

### Removed
- Converter ecosystem feature (not implemented) - tracked in #159

## Related Issues

- Closes: N/A (proactive documentation update)
- Related: #159 (converters package - created as future enhancement)
- Follow-up: #160 (CONTRIBUTING.md stale references)
- Follow-up: #161 (README.md broken doc links)

## Test plan

- [x] All package references verified against actual `packages/*/package.json`
- [x] OIDC documentation verified against `.github/workflows/release.yml`
- [x] No remaining stale references in modified files
- [x] Prettier formatting applied via pre-commit hook