### PR TITLE
fix(device-profiler): display error message instead of [object Object]

### DIFF
--- a/packages/device-profiler/src/console-formatter.test.ts
+++ b/packages/device-profiler/src/console-formatter.test.ts
@@ -225,4 +225,71 @@ describe('formatSummary', () => {
     // Should display stringified error
     expect(output).toContain('Port is busy')
   })
+
+  it('should handle null error', () => {
+    const results: ScanResult[] = [
+      {
+        address: 0,
+        type: RegisterType.Holding,
+        success: false,
+        timing: 100,
+        error: null as unknown as string,
+        errorType: ErrorType.Unknown,
+      },
+    ]
+
+    const output = formatSummary(results)
+    // Count occurrences of '-' (should have at least 2: value and error)
+    const dashes = (output.match(/-/g) ?? []).length
+    expect(dashes).toBeGreaterThanOrEqual(2)
+  })
+
+  it('should handle undefined error', () => {
+    const results: ScanResult[] = [
+      {
+        address: 0,
+        type: RegisterType.Holding,
+        success: false,
+        timing: 100,
+        errorType: ErrorType.Unknown,
+      },
+    ]
+
+    const output = formatSummary(results)
+    const dashes = (output.match(/-/g) ?? []).length
+    expect(dashes).toBeGreaterThanOrEqual(2)
+  })
+
+  it('should handle Error instance', () => {
+    const results: ScanResult[] = [
+      {
+        address: 0,
+        type: RegisterType.Holding,
+        success: false,
+        timing: 100,
+        error: new Error('Connection refused') as unknown as string,
+        errorType: ErrorType.Unknown,
+      },
+    ]
+
+    const output = formatSummary(results)
+    expect(output).toContain('Connection refused')
+  })
+
+  it('should handle object without message property', () => {
+    const results: ScanResult[] = [
+      {
+        address: 0,
+        type: RegisterType.Holding,
+        success: false,
+        timing: 100,
+        error: { code: 'EBUSY', errno: -16 } as unknown as string,
+        errorType: ErrorType.Unknown,
+      },
+    ]
+
+    const output = formatSummary(results)
+    // Should JSON stringify the object
+    expect(output).toContain('EBUSY')
+  })
 })

--- a/packages/device-profiler/src/console-formatter.ts
+++ b/packages/device-profiler/src/console-formatter.ts
@@ -11,7 +11,12 @@ function formatError(error: unknown): string {
   if (typeof error === 'string') return error
   if (error instanceof Error) return error.message
   if (typeof error === 'object' && 'message' in error) return String(error.message)
-  return JSON.stringify(error)
+  try {
+    return JSON.stringify(error)
+  } catch {
+    // Fallback for circular references or BigInt - return type name
+    return `[${typeof error}]`
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `formatError()` helper function to properly serialize error objects for display
- Handle all error types: null, undefined, string, Error instances, objects with message property
- Wrap JSON.stringify in try/catch to prevent crashes on circular references or BigInt
- Add comprehensive test coverage for all error formatting branches

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)