### PR TITLE
ci: add CodeQL code scanning workflow

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,14 @@
+name: ya-modbus CodeQL config
+
+paths:
+  - packages/
+  - .github/
+
+paths-ignore:
+  - '**/node_modules/**'
+  - '**/dist/**'
+  - '**/coverage/**'
+  - '**/*.test.ts'
+  - '**/*.spec.ts'
+  - '**/__tests__/**'
+  - '**/__mocks__/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,59 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/**/*.ts'
+      - '.github/workflows/**'
+      - '.github/codeql/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/**/*.ts'
+      - '.github/workflows/**'
+      - '.github/codeql/**'
+  schedule:
+    - cron: '30 4 * * 1' # Weekly on Monday at 4:30 AM UTC
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+          - language: actions
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-and-quality
+          config-file: .github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Summary

- Add GitHub CodeQL security scanning for JavaScript/TypeScript and GitHub Actions workflows
- Use `security-and-quality` query suite for comprehensive vulnerability and code quality detection
- Configure path-based triggers and weekly scheduled scans

## Test plan

- [ ] Verify workflow triggers on PR (this PR itself)
- [ ] Check CodeQL analysis completes for both languages
- [ ] Confirm results appear in Security tab after merge