### PR TITLE
fix(ci): prevent code injection in cleanup-prerelease workflow

### DIFF
--- a/.github/workflows/cleanup-prerelease.yml
+++ b/.github/workflows/cleanup-prerelease.yml
@@ -93,11 +93,13 @@ jobs:
 
       - name: Summary
         if: always()
+        env:
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
           echo "## Pre-release Cleanup Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- PR: #${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Branch: ${{ github.event.pull_request.head.ref }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Branch: $PR_BRANCH" >> $GITHUB_STEP_SUMMARY
           echo "- Status: ${{ github.event.pull_request.merged && 'Merged' || 'Closed without merge' }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 


### PR DESCRIPTION
Potential fix for [https://github.com/groupsky/ya-modbus/security/code-scanning/10](https://github.com/groupsky/ya-modbus/security/code-scanning/10)

In general, to fix this kind of problem in GitHub Actions, we should avoid placing `${{ ... }}` expressions that contain untrusted input directly inside `run:` scripts. Instead, assign the untrusted value to an environment variable using the workflow expression syntax, and then reference that value inside the script using the shell’s native variable expansion. This prevents the untrusted data from being interpreted as part of the shell script structure because the expression is resolved before the shell runs and then substituted as a simple environment variable value.

For this specific workflow, we should change the `Summary` step so it no longer embeds `${{ github.event.pull_request.head.ref }}` directly in the `run:` block. We can add an `env:` section under that step with a key like `PR_BRANCH` set via `PR_BRANCH: ${{ github.event.pull_request.head.ref }}`. Inside the `run:` script, we then replace the `echo` line that currently uses the expression syntax with one that uses shell syntax, e.g., `echo "- Branch: $PR_BRANCH" >> $GITHUB_STEP_SUMMARY`. This preserves the existing functionality (the branch name still appears in the summary) while eliminating the direct interpolation of untrusted input into the shell. All other uses of `${{ ... }}` in this step either refer to step outputs (which are our own) or to booleans/strings that are not user controlled in the same way; the reported issue is specifically about the branch ref. No new methods or external tools are necessary; we only need to adjust the YAML step definition to introduce the environment variable and use it correctly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
