### PR TITLE
refactor(ci): remove redundant build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,36 +119,3 @@ jobs:
           fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    needs: [setup, test]
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js from .nvmrc
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build all packages
-        run: npm run build
-
-      - name: Check for build artifacts
-        run: |
-          if [ ! -d "packages/driver-types/dist" ]; then
-            echo "Error: driver-types build failed"
-            exit 1
-          fi
-          if [ ! -d "packages/driver-xymd1/dist" ]; then
-            echo "Error: driver-xymd1 build failed"
-            exit 1
-          fi
-          echo "All packages built successfully"


### PR DESCRIPTION
## Summary

- Remove the separate `build` job from CI workflow as it duplicates work already done in the `test` job
- The test job runs `npm run build` for all Node.js versions including the latest (which matches `.nvmrc`)
- Reduces CI time by eliminating redundant checkout, npm ci, and build steps

## Test plan

- [x] Verify CI passes with only the test job
- [x] Confirm build failures would still be caught by the test job