### PR TITLE
refactor(docs): simplify agent configuration symlinks

### DIFF
--- a/.aider.md
+++ b/.aider.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/.cursor/rules/agents
+++ b/.cursor/rules/agents
@@ -1,0 +1,1 @@
+../../docs/agents

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/.github/.aider.md
+++ b/.github/.aider.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/.github/.cursorrules
+++ b/.github/.cursorrules
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,9 +1,0 @@
-# GitHub Configuration
-
-CI/CD and repository settings.
-
-## Required Reading
-
-READ docs/agents/workflows.md BEFORE modifying workflows or CI/CD configuration.
-
-READ docs/agents/release.md BEFORE modifying release or publishing workflows.

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,10 +45,10 @@ Reading task-specific documentation prevents implementation errors and ensures y
 → READ docs/agents/release.md (Lerna-Lite, versioning, npm publishing)
 
 **Before modifying these docs:**
-→ READ docs/agents/maintenance.md
+→ READ docs/agents/agent-docs.md
 
 **Before modifying CI/CD:**
-→ READ docs/agents/workflows.md or .github/AGENTS.md
+→ READ docs/agents/workflows.md
 
 **For architecture questions:**
 → READ docs/ARCHITECTURE.md

--- a/docs/agents/agent-docs.md
+++ b/docs/agents/agent-docs.md
@@ -1,8 +1,11 @@
 ---
-paths: /**/{AGENTS,CLAUDE,.aider}.md, /**/.cursorrules, /.github/copilot-instructions.md, /**/docs/agents/*.md, /**/.claude/rules/**/*.md
+paths: /**/{AGENTS,CLAUDE}.md, /.github/copilot-instructions.md, /**/docs/agents/*.md, /**/.claude/rules/**/*.md, /**/.cursor/rules/**/*.md
 ---
 
 # Agent Documentation Maintenance
+
+AGENTS.md files provide instructions to AI coding agents (Claude, Cursor, Copilot, etc.).
+AI tooling automatically reads these files and includes them in the agent's context.
 
 ## Core Principles
 
@@ -21,13 +24,20 @@ paths: /**/{AGENTS,CLAUDE,.aider}.md, /**/.cursorrules, /.github/copilot-instruc
 - Points to docs/agents/\*.md for detailed guidelines
 - Use ALL CAPS for imperative keywords (READ, BEFORE, NEVER, ALWAYS, MUST)
 - NEVER include code examples or violation demonstrations
-- NEVER duplicate information from parent directory AGENTS.md files
+
+## Scope & Inheritance
+
+- AGENTS.md can be placed in any directory
+- Applies to all files within that directory (recursively)
+- Nested AGENTS.md extends and overrides parent AGENTS.md
+- Child docs should NOT repeat parent instructions
 
 ## File Naming
 
 - Canonical: AGENTS.md
-- Symlinks: CLAUDE.md, .aider.md, .cursorrules → AGENTS.md
-- Agent docs: .claude/rules/agents → docs/agents (for Claude Desktop)
+- Symlinks: CLAUDE.md → AGENTS.md
+- Agent docs: .claude/rules/agents → docs/agents (Claude Code)
+- Agent docs: .cursor/rules/agents → docs/agents (Cursor IDE)
 
 ## Frontmatter
 

--- a/packages/cli/.aider.md
+++ b/packages/cli/.aider.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/packages/cli/.cursor/rules/agents
+++ b/packages/cli/.cursor/rules/agents
@@ -1,0 +1,1 @@
+../../docs/agents

--- a/packages/cli/.cursorrules
+++ b/packages/cli/.cursorrules
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/packages/mqtt-bridge/.aider.md
+++ b/packages/mqtt-bridge/.aider.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/packages/mqtt-bridge/.cursor/rules/agents
+++ b/packages/mqtt-bridge/.cursor/rules/agents
@@ -1,0 +1,1 @@
+../../docs/agents

--- a/packages/mqtt-bridge/.cursorrules
+++ b/packages/mqtt-bridge/.cursorrules
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/packages/transport/.aider.md
+++ b/packages/transport/.aider.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/packages/transport/.cursorrules
+++ b/packages/transport/.cursorrules
@@ -1,1 +1,0 @@
-AGENTS.md


### PR DESCRIPTION
## Summary

- Remove legacy `.cursorrules` and `.aider.md` symlinks
- Add `.cursor/rules/agents -> docs/agents` symlinks for Cursor IDE
- Remove `.github/AGENTS.md` (CI docs covered by `docs/agents/workflows.md`)
- Rename `maintenance.md` to `agent-docs.md` with improved documentation on scope, inheritance, and purpose

## Test plan

- [x] Verify Cursor IDE picks up rules from `.cursor/rules/agents`
- [x] Verify Claude Code still works with `.claude/rules/agents`