### PR TITLE
docs: add first-time package publishing workflow for trusted publishers

### DIFF
--- a/docs/NEW-PACKAGE.md
+++ b/docs/NEW-PACKAGE.md
@@ -134,7 +134,7 @@ After creating the package:
 
 ## First-Time NPM Publishing
 
-When publishing a new package to npm for the first time, you must publish manually before automated releases will work. This is due to a "chicken and egg" problem with npm trusted publishers:
+When publishing a new package to npm for the first time, you MUST publish manually before automated releases will work. This is due to a "chicken and egg" problem with npm trusted publishers:
 
 - Trusted publishers require the package to already exist on npm
 - The package doesn't exist until you publish it
@@ -152,9 +152,9 @@ When publishing a new package to npm for the first time, you must publish manual
 
 2. **Configure trusted publisher** on npm:
    - Go to package settings on npm.com
-   - Add trusted publisher with: owner=`groupsky`, repo=`ya-modbus`, workflow=`release.yml`, environment=`npm`
+   - Add trusted publisher with: owner=`<github-owner>`, repo=`<repo-name>`, workflow=`release.yml`, environment=`npm`
 
-3. **Verify** by triggering a pre-release from a feature branch
+3. **Verify** by triggering a pre-release workflow (see [Release Process](agents/release.md) for details)
 
 See [PUBLISHING-SETUP.md](PUBLISHING-SETUP.md#first-time-package-publishing) for detailed instructions.
 

--- a/docs/PUBLISHING-SETUP.md
+++ b/docs/PUBLISHING-SETUP.md
@@ -46,7 +46,7 @@ See: https://docs.npmjs.com/trusted-publishers for detailed setup
 
 ## First-Time Package Publishing
 
-When creating a new package, you must publish it manually before the trusted publisher workflow can work. This is because npm trusted publishers can only be configured for packages that already exist on the registry.
+When creating a new package, you MUST publish it manually before the trusted publisher workflow can work. This is because npm trusted publishers can only be configured for packages that already exist on the registry.
 
 ### The Chicken-and-Egg Problem
 
@@ -78,8 +78,8 @@ After the package exists on npm:
 1. Go to your package on npm (e.g., https://www.npmjs.com/package/@ya-modbus/your-package)
 2. Navigate to **Settings** → **Trusted Publishers**
 3. Click **Add trusted publisher** and fill in:
-   - **Repository owner**: `groupsky` (or your GitHub organization/user)
-   - **Repository name**: `ya-modbus`
+   - **Repository owner**: Your GitHub organization or username
+   - **Repository name**: Your repository name
    - **Workflow file**: `release.yml`
    - **Environment**: `npm`
 
@@ -88,7 +88,7 @@ After the package exists on npm:
 Trigger a test release to confirm the trusted publisher is working:
 
 1. Create a feature branch with a minor change
-2. Open a PR and trigger a manual pre-release workflow
+2. Open a PR and trigger a manual pre-release workflow (see `docs/agents/release.md` for details)
 3. Verify the workflow publishes successfully with provenance
 
 ## GitHub Token (Automatic)

--- a/docs/agents/package-creation.md
+++ b/docs/agents/package-creation.md
@@ -66,9 +66,9 @@ Before committing:
 4. Coverage meets 95% thresholds
 5. Package added to root jest.config.js
 
-Before first release:
+Before merging to main (for publishable packages):
 
-6. First-time npm publish completed manually (see docs/PUBLISHING-SETUP.md)
+6. First-time npm publish completed manually (see `docs/PUBLISHING-SETUP.md`)
 7. Trusted publisher configured on npm.com
 
 ## References


### PR DESCRIPTION
## Summary

- Document the "chicken and egg" problem with npm trusted publishers
- Add step-by-step instructions for manual first publish workflow
- New packages MUST be published manually before merging to main

## Changes

- `docs/PUBLISHING-SETUP.md`: Added "First-Time Package Publishing" section with detailed steps
- `docs/NEW-PACKAGE.md`: Added quick reference section for first-time publishing
- `docs/agents/package-creation.md`: Added publishing verification steps to checklist

## Key points documented

1. Manual first publish required (trusted publishers only work for existing packages)
2. Configure trusted publisher on npm.com after first publish
3. Verify by triggering a pre-release workflow

## Test plan

- [ ] Review documentation for clarity and accuracy
- [ ] Verify links between documents work correctly
- [ ] Confirm style consistency with existing docs