### PR TITLE
fix(ci): correct markdown code fence formatting in PR comments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,7 +289,8 @@ jobs:
 
           Install any of the published packages using the dist-tag:
           \`\`\`bash
-          ${INSTALL_COMMANDS}\`\`\`
+          ${INSTALL_COMMANDS}
+          \`\`\`
 
           ### Manual Cleanup
 
@@ -297,7 +298,8 @@ jobs:
 
           \`\`\`bash
           # Remove dist-tags (requires npm authentication):
-          ${CLEANUP_COMMANDS}\`\`\`
+          ${CLEANUP_COMMANDS}
+          \`\`\`
 
           > **Note**: Cleanup is optional. Published versions remain available via exact version install (e.g., \`npm install @ya-modbus/cli@0.6.1-pr123.0+abc1234\`) even after the dist-tag is removed.
 


### PR DESCRIPTION
## Summary

Fixes markdown formatting in the release workflow's PR comment by ensuring proper line breaks before closing code fences for install and cleanup command blocks.

## Changes

- Added newline before closing code fence in install commands section
- Added newline before closing code fence in cleanup commands section

This ensures proper markdown rendering in GitHub PR comments.