### PR TITLE
fix(ci): remove path filters from CodeQL workflow to unblock dependency PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,16 +3,8 @@ name: CodeQL
 on:
   push:
     branches: [main]
-    paths:
-      - 'packages/**/*.ts'
-      - '.github/workflows/**'
-      - '.github/codeql/**'
   pull_request:
     branches: [main]
-    paths:
-      - 'packages/**/*.ts'
-      - '.github/workflows/**'
-      - '.github/codeql/**'
   schedule:
     - cron: '30 4 * * 1' # Weekly on Monday at 4:30 AM UTC
 


### PR DESCRIPTION
## Summary

Removes path filters from the CodeQL workflow to ensure it runs on all PRs, including dependency updates from Dependabot.

## Problem

The repository has a ruleset that requires CodeQL checks on all PRs to the main branch. However, the CodeQL workflow had path filters that only triggered on:
- `packages/**/*.ts`
- `.github/workflows/**`
- `.github/codeql/**`

This meant CodeQL never ran on Dependabot PRs (which only modify `package.json` and `package-lock.json`), causing them to be blocked by the required check.

## Solution

Removed the path filters so CodeQL runs on all PRs. This:
- Unblocks Dependabot PRs (#201, #202, #203, #204, #205, #206)
- Ensures security scanning runs on dependency updates
- Satisfies the repository ruleset requirements

## Test Plan

- [x] Verify CodeQL workflow triggers on this PR
- [ ] Confirm blocked Dependabot PRs can proceed after merge