### PR TITLE
chore(deps): group lerna-lite dependencies in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -116,6 +116,14 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+      # Lerna monorepo management - MUST be upgraded together
+      npm-lerna:
+        applies-to: version-updates
+        patterns:
+          - '@lerna-lite/*'
+        update-types:
+          - 'minor'
+          - 'patch'
       # Note: Security updates are not grouped - they create immediate individual PRs
     open-pull-requests-limit: 10
     rebase-strategy: 'auto'


### PR DESCRIPTION
## Summary

- Add `npm-lerna` group to dependabot.yml to ensure all `@lerna-lite/*` packages are updated together

## Problem

Currently, dependabot creates separate PRs for each lerna-lite package (cli, run, changed, publish, version), resulting in 5 individual PRs when lerna-lite releases updates. This is similar to the issue we solved for the ESLint ecosystem.

## Solution

Add a dependency group for lerna-lite packages, similar to the existing `npm-eslint-ecosystem` group. This ensures all lerna-lite packages are upgraded atomically in a single PR.

## Impact

Future lerna-lite updates will be grouped into a single PR instead of 5 separate ones, reducing PR noise and ensuring coherent upgrades of interdependent packages.