### PR TITLE
docs(emulator): add missing basic-tcp.yaml example

### DIFF
--- a/packages/emulator/examples/config-files/basic-tcp.yaml
+++ b/packages/emulator/examples/config-files/basic-tcp.yaml
@@ -1,0 +1,14 @@
+# Basic TCP emulator configuration
+# Usage: ya-modbus-emulator --config basic-tcp.yaml
+
+transport:
+  type: tcp
+  host: 0.0.0.0
+  port: 502
+
+devices:
+  - slaveId: 1
+    registers:
+      holding:
+        0: 230 # Voltage * 10 = 23.0V
+        1: 52 # Current * 10 = 5.2A


### PR DESCRIPTION
## Summary

Fixes broken documentation by adding the missing `basic-tcp.yaml` example file that was referenced in the README but didn't exist in the repository.

## Changes

- Added `packages/emulator/examples/config-files/basic-tcp.yaml`
- Content matches the example shown in README.md
- Follows same structure and comment style as other example files (basic-rtu.yaml, etc.)
- Demonstrates TCP transport configuration on standard Modbus port 502

## Testing

- ✅ YAML syntax validated with js-yaml parser
- ✅ Emulator runs successfully with the config file
- ✅ File structure consistent with existing examples

Closes #255